### PR TITLE
Feature(Model): Publish options

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -164,7 +164,11 @@ class Draftsman::Draft < ActiveRecord::Base
   # -  For `update` drafts, applies the drafted changes to the item and destroys
   #    the draft.
   # -  For `destroy` drafts, destroys the item and the draft.
-  def publish!
+  #
+  # Params:
+  # -  A hash of options that will be passed to item.save,
+  #    override publish_options defined with has_drafts
+  def publish!(**options)
     ActiveRecord::Base.transaction do
       case self.event.to_sym
       when :create, :update
@@ -180,7 +184,7 @@ class Draftsman::Draft < ActiveRecord::Base
         # Clear out draft
         self.item.send("#{self.item.class.draft_association_name}_id=", nil)
 
-        self.item.save(validate: false)
+        self.item.save(self.item.draftsman_options[:publish_options].merge(options))
         self.item.reload
 
         # Destroy draft

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -52,6 +52,10 @@ module Draftsman
       # :trashed_at
       # The name to use for the method which returns the soft delete timestamp.
       # Default is `trashed_at`.
+      #
+      # :publish_options
+      # The hash of options that will be passed to #save when publishing the draft.
+      # Default is { valdiate: false }
       def has_drafts(options = {})
         # Lazily include the instance methods so we don't clutter up
         # any more ActiveRecord models than we need to.
@@ -80,6 +84,8 @@ module Draftsman
         draftsman_options[:ignore] << "#{self.draft_association_name}_id"
 
         draftsman_options[:meta] ||= {}
+
+        draftsman_options[:publish_options] ||= { validate: false }
 
         attr_accessor :draftsman_event
 

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -520,6 +520,14 @@ describe Draftsman::Draft do
         it 'deletes the draft record' do
           expect { trashable.draft.publish! }.to change(Draftsman::Draft, :count).by(-1)
         end
+
+        context 'when publish options is { validate: true }' do
+          it 'validates the record before publishing' do
+            expect(trashable.draft.item).to receive(:valid?).and_call_original
+
+            trashable.draft.publish!(validate: true)
+          end
+        end
       end # with `create` draft
 
       context 'with `update` draft' do
@@ -579,6 +587,14 @@ describe Draftsman::Draft do
 
         it 'does not delete the associated item' do
           expect { trashable.draft.publish! }.to_not change(Trashable, :count)
+        end
+
+        context 'when publish options is { validate: true }' do
+          it 'validates the record before publishing' do
+            expect(trashable.draft.item).to receive(:valid?).and_call_original
+
+            trashable.draft.publish!(validate: true)
+          end
         end
       end # with `update` draft
 

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -5,6 +5,16 @@ describe Vanilla do
   let(:vanilla) { Vanilla.new(name: 'Bob') }
   it { should be_draftable }
 
+  describe '#draftsman_options' do    
+    describe '[:publish_options]' do
+      subject { vanilla.draftsman_options[:publish_options] }
+
+      it { is_expected.to be_present }
+      it { is_expected.to be_a(Hash) }
+      it { is_expected.to include(validate: false) }
+    end
+  end
+
   describe '#object_attrs_for_draft_record' do
     it 'contains column name' do
       expect(vanilla.object_attrs_for_draft_record).to include 'name'


### PR DESCRIPTION
+ Add `publish_options` to the options of `has_drafts`. It will be passed to `item.save` when publishing.
+ Add `options` argument to `Draft#publish!`. It overrides `publish_options`.